### PR TITLE
blog(feat): add initial page

### DIFF
--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -1,16 +1,19 @@
 import React from "react"
-import { Link } from "gatsby"
 
-import Layout from "../components/layout"
+import Layout from "../components/Template/Layout"
 import SEO from "../components/seo"
 
-const SecondPage = () => (
+const Blog = () => (
   <Layout>
-    <SEO title="Page two" />
-    <h1>Hi from the second page</h1>
-    <p>Welcome to page 2</p>
-    <Link to="/">Go back to the homepage</Link>
+    <SEO title="Blog" />
+    <section className="section is-large">
+      <div className="columns has-text-centered is-centered">
+        <div className="column is-8">
+          <h1 className="title mb-4">Coming Soon!</h1>
+        </div>
+      </div>
+    </section>
   </Layout>
 )
 
-export default SecondPage
+export default Blog


### PR DESCRIPTION
**Describe the Feature** 
- add initial page for `blog`

**Related Issue** 
Closes #22 

**Expected Behavior**
Steps to reproduce behavior:

1. Go to `localhost:8000`
2. Click on `BLOG` navbar link
3. See result
![Screen Shot 2019-08-03 at 7 56 15 PM](https://user-images.githubusercontent.com/33680528/62411642-c9142b00-b628-11e9-9cbc-621db49f8c45.png)